### PR TITLE
Add option to generate bitflip visualisations

### DIFF
--- a/doc/general.rst
+++ b/doc/general.rst
@@ -335,8 +335,9 @@ User can choose a pattern that memory will be initially filled with:
 * ``rand_per_row`` - random values for all rows
 
 There are also two versions of a rowhammer script:
-* ``rowhammer.py`` - this one uses Processing System to fill/check the memory
-* ``hw_rowhammer.py`` - BIST blocks will be used to fill/check the memory
+
+* ``rowhammer.py`` - this one uses regular memory access via EtherBone to fill/check the memory (slower)
+* ``hw_rowhammer.py`` - BIST blocks will be used to fill/check the memory (much faster, but with some limitations regarding fill pattern)
 
 BIST blocks are faster and are the intended way of running Row Hammer Tester.
 

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -367,6 +367,35 @@ Example:
    Bit-flips for row   132: 12
    Bit-flips for row   134: 3
 
+
+**Plotting**
+
+The scripts can also generate a plot that shows the bit-flip locations. To generate the plot pass the ``--plot`` argument.
+
+.. note::
+
+   To use this feature make sure to install additional Python dependencies using ``pip install -r requirements-dev.txt`` when inside the virtual environment.
+
+Additionally there is support for integrating with the `SymbiFlow Database Visualizer <https://github.com/antmicro/symbiflow-database-visualizer>`_.
+To use it first clone and build the visualizer with:
+
+.. code-block:: sh
+
+   git clone https://github.com/antmicro/symbiflow-database-visualizer
+   cd symbiflow-database-visualizer
+   npm run build
+
+Next run ``rowhammer.py`` or ``hw_rowhammer.py`` with the ``--plot`` argument, which will generate JSON files in ``vis/`` directory.
+Then copy the files from ``vis`` to ``symbiflow-database-visualizer/dist/production/`` and start a HTTP server in the ``production`` directory:
+
+.. code-block:: sh
+
+   cp vis/* symbiflow-database-visualizer/dist/production/
+   cd symbiflow-database-visualizer/dist/production/
+   python -m http.server 8080
+
+Then open the address ``http://0.0.0.0:8080/`` in your browser to view the visualization.
+
 bios_console.py
 ~~~~~~~~~~~~~~~
 

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -6,7 +6,7 @@ The `Playbook directory <https://github.com/antmicro/litex-rowhammer-tester/tree
 Payload
 -------
 
-Tests are generated as ``payload`` data. After generation, this data is transferred to a memory area in the device reserved for this purpose called ``payload memory``. The payload contains an instruction list that can be interpreted by the``payload executor`` module in hardware. The payload executor translates these instructions into DRAM commands. The payload executor connects directly to the DRAM PHY, bypassing DRAM controller, as explained in :ref:`architecture`.
+Tests are generated as ``payload`` data. After generation, this data is transferred to a memory area in the device reserved for this purpose called ``payload memory``. The payload contains an instruction list that can be interpreted by the ``payload executor`` module in hardware. The payload executor translates these instructions into DRAM commands. The payload executor connects directly to the DRAM PHY, bypassing DRAM controller, as explained in :ref:`architecture`.
 
 Changing payload memory size
 ****************************
@@ -100,12 +100,12 @@ Expected output:
     Payload per-row toggle count = 0.010K  x10 rows
     Payload refreshes (if enabled) = 10 (disabled)
     Expected execution time = 1903 cycles = 0.019 ms
-  
+
   Transferring the payload ...
-  
+
   Executing ...
   Time taken: 0.738 ms
-  
+
   Progress: [==                                      ]  3338 / 65536 (Errors: 1287)
   ...
 
@@ -148,7 +148,7 @@ Expected output:
 
 .. code-block:: console
 
-  Progress: [========================================] 3072 / 3072 
+  Progress: [========================================] 3072 / 3072
   Generating payload:
     tRAS = 5
     tRP = 3
@@ -160,13 +160,13 @@ Expected output:
     Payload per-row toggle count = 0.010K  x2 rows
     Payload refreshes (if enabled) = 10 (disabled)
     Expected execution time = 1263 cycles = 0.013 ms
-  
+
   Transferring the payload ...
-  
+
   Executing ...
   Time taken: 0.647 ms
-  
-  Progress: [============                            ]  323 / 1024 (Errors: 320) 
+
+  Progress: [============                            ]  323 / 1024 (Errors: 320)
   ...
 
 Configurations

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 ipython
 ipdb
 matplotlib
+numpy
 pyqt5

--- a/rowhammer_tester/scripts/hw_rowhammer.py
+++ b/rowhammer_tester/scripts/hw_rowhammer.py
@@ -103,7 +103,7 @@ class HwRowHammer(RowHammer):
                 print('OK')
             else:
                 print()
-                self.display_errors(errors)
+                self.display_errors(errors, row_pairs)
                 return
 
         if self.no_refresh:
@@ -132,7 +132,7 @@ class HwRowHammer(RowHammer):
             print('OK')
         else:
             print()
-            self.display_errors(errors)
+            self.display_errors(errors, row_pairs)
             return
 
 


### PR DESCRIPTION
This PR adds support for generating visual representation of error lists by adding `--plot` switch when calling `rowhammer.py` or `hw_rowhammer.py`

At the moment two representations are generated:

* 2D Histogram
![image](https://user-images.githubusercontent.com/45362851/127511690-d0165dbf-dc2b-4cb0-b493-873c095421b4.png)

* JSON files used with [Symbiflow DB Visualiser](https://github.com/antmicro/symbiflow-database-visualizer)
![image](https://user-images.githubusercontent.com/45362851/127511855-9568a277-cc3b-49ca-8ea5-50c266b14a84.png)

To view results using DB Visualiser you need to:

* Clone and build the visualiser with
```
git clone https://github.com/antmicro/symbiflow-database-visualizer
cd symbiflow-database-visualizer
npm run build
```
* Run `rowhammer.py` or `hw_rowhammer.py` with `--plot`
* Copy generated JSON files from `vis` directory to `/path/to/symbiflow-database-visualizer/dist/production/`
* Start a simple HTTP server inside the `production` directory: `python -m http.server 8080`