### PR TITLE
Remove "litex-" prefix from project name

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout litex-rowhammer-tester
+      - name: Checkout rowhammer-tester
         uses: actions/checkout@v2
         with:
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Checkout litex-rowhammer-tester
+      - name: Checkout rowhammer-tester
         uses: actions/checkout@v2
         with:
           persist-credentials: false

--- a/doc/dram_modules.rst
+++ b/doc/dram_modules.rst
@@ -1,7 +1,7 @@
 DRAM modules
 ============
 
-When building one of the targets in `rowhammer_tester/targets <https://github.com/antmicro/litex-rowhammer-tester/tree/master/rowhammer_tester/targets>`_, a custom DRAM module can be specified using the ``--module`` argument. To find the default modules for each target, check the output of ``--help``.
+When building one of the targets in `rowhammer_tester/targets <https://github.com/antmicro/rowhammer-tester/tree/master/rowhammer_tester/targets>`_, a custom DRAM module can be specified using the ``--module`` argument. To find the default modules for each target, check the output of ``--help``.
 
 .. note::
 
@@ -17,7 +17,7 @@ Adding new modules
 Supported modules can be found in `litedram/modules.py <https://github.com/enjoy-digital/litedram/blob/master/litedram/modules.py>`_.
 If a module is not listed there, you can add a new definition.
 
-To make developement more convenient, modules can be added in litex-rowhammer-tester repository directly in file `rowhammer_tester/targets/modules.py <https://github.com/antmicro/litex-rowhammer-tester/blob/master/rowhammer_tester/targets/modules.py>`_. These definitions will be used before definitions in LiteDRAM.
+To make developement more convenient, modules can be added in rowhammer-tester repository directly in file `rowhammer_tester/targets/modules.py <https://github.com/antmicro/rowhammer-tester/blob/master/rowhammer_tester/targets/modules.py>`_. These definitions will be used before definitions in LiteDRAM.
 
 .. note::
 

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -66,12 +66,12 @@ To flash QSPI flash module on LPDDR4 Test Board you'll need a patched version of
 Row-hammer tester
 ^^^^^^^^^^^^^^^^^
 
-Now clone the ``litex-rowhammer-tester`` repository and install the rest of the required dependecies:
+Now clone the ``rowhammer-tester`` repository and install the rest of the required dependecies:
 
 .. code-block:: sh
 
-   git clone --recursive https://github.com/antmicro/litex-rowhammer-tester.git
-   cd litex-rowhammer-tester
+   git clone --recursive https://github.com/antmicro/rowhammer-tester.git
+   cd rowhammer-tester
    make deps
 
 The last command will download and build all the dependencies (inlcuding a RISC-V GCC toolchain)

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -1,7 +1,7 @@
 Playbook
 ========
 
-The `Playbook directory <https://github.com/antmicro/litex-rowhammer-tester/tree/master/rowhammer_tester/scripts/playbook>`_ contains a group of Python classes and scripts designed to simplify the process of writing various rowhammer-related tests. These tests can be executed against a hardware platform.
+The `Playbook directory <https://github.com/antmicro/rowhammer-tester/tree/master/rowhammer_tester/scripts/playbook>`_ contains a group of Python classes and scripts designed to simplify the process of writing various rowhammer-related tests. These tests can be executed against a hardware platform.
 
 Payload
 -------
@@ -12,7 +12,7 @@ Changing payload memory size
 ****************************
 
 Payload memory size can be changed. Of course it can't exceed the memory available on the hardware platform used.
-Currently, the payload memory size is defined in `common.py <https://github.com/antmicro/litex-rowhammer-tester/blob/master/rowhammer_tester/targets/common.py>`_, as an argument to LiteX:
+Currently, the payload memory size is defined in `common.py <https://github.com/antmicro/rowhammer-tester/blob/master/rowhammer_tester/targets/common.py>`_, as an argument to LiteX:
 
 .. code-block:: python
 
@@ -60,7 +60,7 @@ Payload generator class
 -----------------------
 
 The purpose of the payload generator is to prepare a payload and process the test outcome. It is a class that can be re-used in different tests :ref:`configurations`.
-Payload generators are located in `payload_generators directory <https://github.com/antmicro/litex-rowhammer-tester/tree/master/rowhammer_tester/scripts/playbook/payload_generators>`_
+Payload generators are located in `payload_generators directory <https://github.com/antmicro/rowhammer-tester/tree/master/rowhammer_tester/scripts/playbook/payload_generators>`_
 
 Available payload generators
 ****************************
@@ -86,7 +86,7 @@ Here are the configs that can be used in *payload_generator_config* for this pay
 
 Example :ref:`configurations` for this test were provided as ``configs/example_row_list_*.cfg`` files.
 Some of them require a significant amount o memory declared as `payload memory`.
-To execute a minimalistic example from within litex-rowhammer-tester repo, enter:
+To execute a minimalistic example from within rowhammer-tester repo, enter:
 
 .. code-block:: console
 
@@ -152,7 +152,7 @@ The results are a series of histograms with appropriate labeling.
 
 Example :ref:`configurations` for this test were provided as ``configs/example_hammer_*.cfg`` files.
 Some of them require a significant amount o memory declared as `payload memory`.
-To execute a minimalistic example from within litex-rowhammer-tester repo, enter:
+To execute a minimalistic example from within rowhammer-tester repo, enter:
 
 .. code-block:: console
 

--- a/doc/zcu104.rst
+++ b/doc/zcu104.rst
@@ -28,7 +28,7 @@ To use an SD card, configure the switches as follows:
 Preparing SD card
 -----------------
 
-For easiest setup, get the pre-built SD card image ``zcu104.img`` from `github releases <https://github.com/antmicro/litex-rowhammer-tester/releases/tag/zcu104-v0.2>`_. It has to be loaded to the microSD card.
+For easiest setup, get the pre-built SD card image ``zcu104.img`` from `github releases <https://github.com/antmicro/rowhammer-tester/releases/tag/zcu104-v0.2>`_. It has to be loaded to the microSD card.
 To load it to the SD card, insert the card into your PC card slot and find the device name.
 ``lsblk`` can be used to check available devices. Example output can look like:
 
@@ -159,7 +159,7 @@ Connect the ZCU104 board to your local network (or directly to a PC) using an Et
 
 The board uses a static IP address. By default it will be ``192.168.100.50``.
 If it does not conflict with your local network configuration you can skip this section.
-(the default configuration can be found `here <https://github.com/antmicro/litex-rowhammer-tester/blob/master/firmware/zcu104/buildroot/rootfs_overlay/etc/network/interfaces>`_\ ).
+(the default configuration can be found `here <https://github.com/antmicro/rowhammer-tester/blob/master/firmware/zcu104/buildroot/rootfs_overlay/etc/network/interfaces>`_\ ).
 
 To verify connectivity, use ``ping 192.168.100.50``.
 You should see data being transmitted, e.g.

--- a/doc/zcu104_img.rst
+++ b/doc/zcu104_img.rst
@@ -157,7 +157,7 @@ Then prepare configuration using external sources and build everything:
 
 .. code-block:: sh
 
-   make BR2_EXTERNAL=/PATH/TO/REPO/litex-rowhammer-tester/firmware/zcu104/buildroot zynqmp_zcu104_defconfig
+   make BR2_EXTERNAL=/PATH/TO/REPO/rowhammer-tester/firmware/zcu104/buildroot zynqmp_zcu104_defconfig
    make -j`nproc`
 
 Flashing SD card
@@ -193,7 +193,7 @@ Mount the boot partition and copy the boot files and kernel image created earlie
 .. code-block:: sh
 
    cp boot.bin /MOUNT/POINT/BOOT/
-   cp /PATH/TO/litex-rowhammer-tester/build/zcu104/gateware/zcu104.bit /MOUNT/POINT/BOOT/
+   cp /PATH/TO/rowhammer-tester/build/zcu104/gateware/zcu104.bit /MOUNT/POINT/BOOT/
    cp /PATH/TO/linux-xlnx/arch/arm64/boot/Image /MOUNT/POINT/BOOT/
    cp /PATH/TO/linux-xlnx/arch/arm64/boot/dts/xilinx/zynqmp-zcu104-revA.dtb /MOUNT/POINT/BOOT/system.dtb
 

--- a/rowhammer_tester/targets/common.py
+++ b/rowhammer_tester/targets/common.py
@@ -405,8 +405,8 @@ def get_sdram_module(name):
     if upstream is None and local is None:
         raise RuntimeError(f'Could not find module {name}')
     if upstream is not None and local is not None:
-        log.warning(f'Module {name} defined both in LiteDRAM and in litex-rowhammer-tester!'
-            ' Consider removing the definition in litex-rowhammer-tester.')
+        log.warning(f'Module {name} defined both in LiteDRAM and in rowhammer-tester!'
+            ' Consider removing the definition in rowhammer-tester.')
     if local is not None:
         log.warning(f'Using module {name} defined locally. Should be moved to LiteDRAM.')
         module = local


### PR DESCRIPTION
Project was renamed from "litex-rowhammer-tester" to "rowhammer-tester"

This commit is a result of running following command:
```
$ find -type f -exec sed -i 's/litex-rowhammer-tester/rowhammer-tester/g' {} \;
```

README.md modification is not commited, as readthedocs subdomain is not changed yet.