### PR TITLE
Bug fixes and doc improvements

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout litex-rowhammer-tester
+      - name: Checkout rowhammer-tester
         uses: actions/checkout@v2
         with:
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Checkout litex-rowhammer-tester
+      - name: Checkout rowhammer-tester
         uses: actions/checkout@v2
         with:
           persist-credentials: false

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ analyzer.csv
 dump.vcd
 sdram_init.py
 vivado.*
+riscv64-unknown-elf-gcc*
+doc/build

--- a/doc/dram_modules.rst
+++ b/doc/dram_modules.rst
@@ -1,7 +1,7 @@
 DRAM modules
 ============
 
-When building one of the targets in `rowhammer_tester/targets <https://github.com/antmicro/litex-rowhammer-tester/tree/master/rowhammer_tester/targets>`_, a custom DRAM module can be specified using the ``--module`` argument. To find the default modules for each target, check the output of ``--help``.
+When building one of the targets in `rowhammer_tester/targets <https://github.com/antmicro/rowhammer-tester/tree/master/rowhammer_tester/targets>`_, a custom DRAM module can be specified using the ``--module`` argument. To find the default modules for each target, check the output of ``--help``.
 
 .. note::
 
@@ -17,7 +17,7 @@ Adding new modules
 Supported modules can be found in `litedram/modules.py <https://github.com/enjoy-digital/litedram/blob/master/litedram/modules.py>`_.
 If a module is not listed there, you can add a new definition.
 
-To make developement more convenient, modules can be added in litex-rowhammer-tester repository directly in file `rowhammer_tester/targets/modules.py <https://github.com/antmicro/litex-rowhammer-tester/blob/master/rowhammer_tester/targets/modules.py>`_. These definitions will be used before definitions in LiteDRAM.
+To make developement more convenient, modules can be added in rowhammer-tester repository directly in file `rowhammer_tester/targets/modules.py <https://github.com/antmicro/rowhammer-tester/blob/master/rowhammer_tester/targets/modules.py>`_. These definitions will be used before definitions in LiteDRAM.
 
 .. note::
 

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -396,6 +396,12 @@ Map all row pairs (from 0 to nrows - 1) and save the error summary in JSON forma
 
   (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --all-rows --no-refresh --read_count 10e4 --log_dir ./test
 
+Map only one row (42 in this case) and save the error summary in JSON format to the ``test`` directory:
+
+.. code-block:: sh
+
+  (venv) $ python hw_rowhammer.py --pattern all_1 --row-pairs const --const-rows-pair 42 42 --no-refresh --read_count 10e4 --log_dir ./test
+
 **Cell retention measurement**:
 
 Perform set of tests for different read count values in a given range for one row pair (50, 100):

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -66,12 +66,12 @@ To flash QSPI flash module on LPDDR4 Test Board you'll need a patched version of
 Row-hammer tester
 ^^^^^^^^^^^^^^^^^
 
-Now clone the ``litex-rowhammer-tester`` repository and install the rest of the required dependecies:
+Now clone the ``rowhammer-tester`` repository and install the rest of the required dependecies:
 
 .. code-block:: sh
 
-   git clone --recursive https://github.com/antmicro/litex-rowhammer-tester.git
-   cd litex-rowhammer-tester
+   git clone --recursive https://github.com/antmicro/rowhammer-tester.git
+   cd rowhammer-tester
    make deps
 
 The last command will download and build all the dependencies (inlcuding a RISC-V GCC toolchain)
@@ -338,6 +338,7 @@ User can choose a pattern that memory will be initially filled with:
 * ``rand_per_row`` - random values for all rows
 
 There are also two versions of a rowhammer script:
+
 * ``rowhammer.py`` - this one uses Processing System to fill/check the memory
 * ``hw_rowhammer.py`` - BIST blocks will be used to fill/check the memory
 
@@ -401,31 +402,31 @@ Perform set of tests for different read count values in a given range for one ro
 
 .. code-block:: sh
 
-  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --row-pairs const --const-rows-pair 50 100 --no-refresh --read_count 10e4 10e5 20e4
+  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --row-pairs const --const-rows-pair 50 100 --no-refresh --read_count_range 10e4 10e5 20e4
 
 Perform set of tests for different read count values in a given range for one row pair (50, 100) and stop the test execution as soon as a bitflip is found:
 
 .. code-block:: sh
 
-  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --row-pairs const --const-rows-pair 50 100 --no-refresh --read_count 10e4 10e5 20e4 --exit-on-bit-flip
+  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --row-pairs const --const-rows-pair 50 100 --no-refresh --read_count_range 10e4 10e5 20e4 --exit-on-bit-flip
 
 Perform set of tests for different read count values in a given range for one row pair (50, 100) and save the error summary in JSON format to the ``test`` directory:
 
 .. code-block:: sh
 
-  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --row-pairs const --const-rows-pair 50 100 --no-refresh --read_count 10e4 10e5 20e4 --log_dir ./test
+  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --row-pairs const --const-rows-pair 50 100 --no-refresh --read_count_range 10e4 10e5 20e4 --log_dir ./test
 
 Perform set of tests for different read count values in a given range for a sequence of attacks for different pairs, where the first row of a pair is 40 and the second one is a row of a number from range (40, nrows - 1):
 
 .. code-block:: sh
 
-  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --row-pairs sequential --start-row 40 --no-refresh --read_count 10e4 10e5 20e4
+  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --row-pairs sequential --start-row 40 --no-refresh --read_count_range 10e4 10e5 20e4
 
 Map all row pairs (from 0 to nrows - 1) and perform a set of tests for different read count values, starting from 10e4 and ending at 10e5 with a step of 20e4 (``--read_count_range [start stop step]``):
 
 .. code-block:: sh
 
-  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --all-rows --no-refresh --read_count 10e4 10e5 20e4
+  (venv) $ python hw_rowhammer.py --nrows 512 --pattern 01_in_row --all-rows --no-refresh --read_count_range 10e4 10e5 20e4
 
 
 bios_console.py

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -1,18 +1,18 @@
 Playbook
 ========
 
-The `Playbook directory <https://github.com/antmicro/litex-rowhammer-tester/tree/master/rowhammer_tester/scripts/playbook>`_ contains a group of Python classes and scripts designed to simplify the process of writing various rowhammer-related tests. These tests can be executed against a hardware platform.
+The `Playbook directory <https://github.com/antmicro/rowhammer-tester/tree/master/rowhammer_tester/scripts/playbook>`_ contains a group of Python classes and scripts designed to simplify the process of writing various rowhammer-related tests. These tests can be executed against a hardware platform.
 
 Payload
 -------
 
-Tests are generated as ``payload`` data. After generation, this data is transferred to a memory area in the device reserved for this purpose called ``payload memory``. The payload contains an instruction list that can be interpreted by the``payload executor`` module in hardware. The payload executor translates these instructions into DRAM commands. The payload executor connects directly to the DRAM PHY, bypassing DRAM controller, as explained in :ref:`architecture`.
+Tests are generated as ``payload`` data. After generation, this data is transferred to a memory area in the device reserved for this purpose called ``payload memory``. The payload contains an instruction list that can be interpreted by the ``payload executor`` module in hardware. The payload executor translates these instructions into DRAM commands. The payload executor connects directly to the DRAM PHY, bypassing DRAM controller, as explained in :ref:`architecture`.
 
 Changing payload memory size
 ****************************
 
 Payload memory size can be changed. Of course it can't exceed the memory available on the hardware platform used.
-Currently, the payload memory size is defined in `common.py <https://github.com/antmicro/litex-rowhammer-tester/blob/master/rowhammer_tester/targets/common.py>`_, as an argument to LiteX:
+Currently, the payload memory size is defined in `common.py <https://github.com/antmicro/rowhammer-tester/blob/master/rowhammer_tester/targets/common.py>`_, as an argument to LiteX:
 
 .. code-block:: python
 
@@ -60,7 +60,7 @@ Payload generator class
 -----------------------
 
 The purpose of the payload generator is to prepare a payload and process the test outcome. It is a class that can be re-used in different tests :ref:`configurations`.
-Payload generators are located in `payload_generators directory <https://github.com/antmicro/litex-rowhammer-tester/tree/master/rowhammer_tester/scripts/playbook/payload_generators>`_
+Payload generators are located in `payload_generators directory <https://github.com/antmicro/rowhammer-tester/tree/master/rowhammer_tester/scripts/playbook/payload_generators>`_
 
 Available payload generators
 ****************************
@@ -86,7 +86,7 @@ Here are the configs that can be used in *payload_generator_config* for this pay
 
 Example :ref:`configurations` for this test were provided as ``configs/example_row_list_*.cfg`` files.
 Some of them require a significant amount o memory declared as `payload memory`.
-To execute a minimalistic example from within litex-rowhammer-tester repo, enter:
+To execute a minimalistic example from within rowhammer-tester repo, enter:
 
 .. code-block:: console
 
@@ -152,7 +152,7 @@ The results are a series of histograms with appropriate labeling.
 
 Example :ref:`configurations` for this test were provided as ``configs/example_hammer_*.cfg`` files.
 Some of them require a significant amount o memory declared as `payload memory`.
-To execute a minimalistic example from within litex-rowhammer-tester repo, enter:
+To execute a minimalistic example from within rowhammer-tester repo, enter:
 
 .. code-block:: console
 

--- a/doc/zcu104.rst
+++ b/doc/zcu104.rst
@@ -28,7 +28,7 @@ To use an SD card, configure the switches as follows:
 Preparing SD card
 -----------------
 
-For easiest setup, get the pre-built SD card image ``zcu104.img`` from `github releases <https://github.com/antmicro/litex-rowhammer-tester/releases/tag/zcu104-v0.2>`_. It has to be loaded to the microSD card.
+For easiest setup, get the pre-built SD card image ``zcu104.img`` from `github releases <https://github.com/antmicro/rowhammer-tester/releases/tag/zcu104-v0.2>`_. It has to be loaded to the microSD card.
 To load it to the SD card, insert the card into your PC card slot and find the device name.
 ``lsblk`` can be used to check available devices. Example output can look like:
 
@@ -159,7 +159,7 @@ Connect the ZCU104 board to your local network (or directly to a PC) using an Et
 
 The board uses a static IP address. By default it will be ``192.168.100.50``.
 If it does not conflict with your local network configuration you can skip this section.
-(the default configuration can be found `here <https://github.com/antmicro/litex-rowhammer-tester/blob/master/firmware/zcu104/buildroot/rootfs_overlay/etc/network/interfaces>`_\ ).
+(the default configuration can be found `here <https://github.com/antmicro/rowhammer-tester/blob/master/firmware/zcu104/buildroot/rootfs_overlay/etc/network/interfaces>`_\ ).
 
 To verify connectivity, use ``ping 192.168.100.50``.
 You should see data being transmitted, e.g.

--- a/doc/zcu104_img.rst
+++ b/doc/zcu104_img.rst
@@ -157,7 +157,7 @@ Then prepare configuration using external sources and build everything:
 
 .. code-block:: sh
 
-   make BR2_EXTERNAL=/PATH/TO/REPO/litex-rowhammer-tester/firmware/zcu104/buildroot zynqmp_zcu104_defconfig
+   make BR2_EXTERNAL=/PATH/TO/REPO/rowhammer-tester/firmware/zcu104/buildroot zynqmp_zcu104_defconfig
    make -j`nproc`
 
 Flashing SD card
@@ -193,7 +193,7 @@ Mount the boot partition and copy the boot files and kernel image created earlie
 .. code-block:: sh
 
    cp boot.bin /MOUNT/POINT/BOOT/
-   cp /PATH/TO/litex-rowhammer-tester/build/zcu104/gateware/zcu104.bit /MOUNT/POINT/BOOT/
+   cp /PATH/TO/rowhammer-tester/build/zcu104/gateware/zcu104.bit /MOUNT/POINT/BOOT/
    cp /PATH/TO/linux-xlnx/arch/arm64/boot/Image /MOUNT/POINT/BOOT/
    cp /PATH/TO/linux-xlnx/arch/arm64/boot/dts/xilinx/zynqmp-zcu104-revA.dtb /MOUNT/POINT/BOOT/system.dtb
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pexpect
 yapf == 0.32.0
 wheel
 pyvcd
+matplotlib
 
 # Documentation
 sphinx

--- a/rowhammer_tester/gateware/bist.py
+++ b/rowhammer_tester/gateware/bist.py
@@ -230,7 +230,7 @@ the `error_ready` CSR is 1. Then use the CSRs `error_offset`,
 transfer. To continue reading, write 1 to `error_continue` CSR.
 Setting `skip_fifo` to 1 will disable this behaviour entirely.
 
-The final nubmer of errors can be read from `error_count`.
+The final number of errors can be read from `error_count`.
 NOTE: This value represents the number of erroneous *DMA transfers*.
 
 The current progress can be read from the `done` CSR.

--- a/rowhammer_tester/gateware/bist.py
+++ b/rowhammer_tester/gateware/bist.py
@@ -10,7 +10,8 @@ from litedram.frontend.dma import LiteDRAMDMAReader, LiteDRAMDMAWriter
 
 
 class PatternMemory(Module):
-    """Memory for storing access pattern
+    """
+    Memory for storing access pattern
 
     It consists of two separate memories: `data` and `addr`, each of `mem_depth`,
     but with different word widths. BIST modules read corresponding pairs (`data`,
@@ -48,7 +49,8 @@ class AddressSelector(Module):
 
 
 class RowDataInverter(Module, AutoCSR):
-    """Inverts data for given range of row bits
+    """
+    Inverts data for given range of row bits
 
     Specify small range, e.g. rowbits=5, keep in mind that
     AddressSelector has to construct one-hot encoded signal
@@ -86,19 +88,19 @@ class RowDataInverter(Module, AutoCSR):
 
 class BISTModule(Module):
     """
-Provides RAM to store access pattern: `mem_addr` and `mem_data`.
-The pattern address space can be limited using the `data_mask`.
+    Provides access to RAM to store access pattern: `mem_addr` and `mem_data`.
+    The pattern address space can be limited using the `data_mask`.
 
-For example, having `mem_adr` filled with `[ 0x04, 0x02, 0x03, ... ]`
-and `mem_data` filled with `[ 0xff, 0xaa, 0x55, ... ]` and setting
-`data_mask = 0b01`, the pattern [(address, data), ...] written will be:
-`[(0x04, 0xff), (0x02, 0xaa), (0x04, 0xff), ...]` (wraps due to masking).
+    For example, having `mem_adr` filled with `[ 0x04, 0x02, 0x03, ... ]`
+    and `mem_data` filled with `[ 0xff, 0xaa, 0x55, ... ]` and setting
+    `data_mask = 0b01`, the pattern [(address, data), ...] written will be:
+    `[(0x04, 0xff), (0x02, 0xaa), (0x04, 0xff), ...]` (wraps due to masking).
 
-DRAM memory range that is being accessed can be configured using `mem_mask`.
+    DRAM memory range that is being accessed can be configured using `mem_mask`.
 
-To use this module, make sure that `ready` is 1, then write the desired
-number of transfers to `count`. Writing to the `start` CSR will initialize
-the operation. When the operation is ongoing `ready` will be 0.
+    To use this module, make sure that `ready` is 1, then write the desired
+    number of transfers to `count`. Writing to the `start` CSR will initialize
+    the operation. When the operation is ongoing `ready` will be 0.
     """
     def __init__(self, pattern_mem):
         self.start = Signal()

--- a/rowhammer_tester/gateware/payload_executor.py
+++ b/rowhammer_tester/gateware/payload_executor.py
@@ -43,7 +43,7 @@ class Decoder(Module):
 
     NOOP with a TIMESLICE of 0 is a special case which is interpreted as
     STOP instruction. When this instruction is encountered execution gets
-    finished imediatelly.
+    finished immediately.
 
     **NOTE:** TIMESLICE is the number of cycles the instruction will take. This
     means that instructions other than NOOP that use TIMESLICE=0 are illegal
@@ -132,7 +132,7 @@ class Encoder:
         self.bankbits = bankbits
 
     class I:
-        """Instuction specification without encoding the value yet"""
+        """Instruction specification without encoding the value yet"""
         def __init__(self, op_code, **kwargs):
             self.op_code = op_code
             for k, v in kwargs.items():

--- a/rowhammer_tester/scripts/hw_rowhammer.py
+++ b/rowhammer_tester/scripts/hw_rowhammer.py
@@ -132,6 +132,7 @@ class HwRowHammer(RowHammer):
         if self.errors_count(errors) == 0:
             print('OK')
             self.bitflip_found = False
+            return {}
         else:
             print()
             errors_in_rows = self.display_errors(errors, read_count, True)

--- a/rowhammer_tester/scripts/hw_rowhammer.py
+++ b/rowhammer_tester/scripts/hw_rowhammer.py
@@ -91,8 +91,9 @@ class HwRowHammer(RowHammer):
             mask = int(mask, 0)
         setup_inverters(self.wb, divisor, mask)
 
+        assert len(row_pairs) > 0, "No pairs to hammer"
         print('\nPreparing ...')
-        row_pattern = list(pattern_generator([self.rows[0]]))[0]
+        row_pattern = list(pattern_generator([row_pairs[0][0]]).values())[0]
         print('WARNING: only single word patterns supported, using: 0x{:08x}'.format(row_pattern))
         print('\nFilling memory with data ...')
         hw_memset(self.wb, 0x0, self.wb.mems.main_ram.size, [row_pattern])

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -261,11 +261,12 @@ class RowHammer:
         if self.errors_count(errors) == 0:
             print('OK')
             self.bitflip_found = False
+            return {}
         else:
             print()
-            self.display_errors(errors, read_count, bool(self.log_directory))
+            errors_in_rows = self.display_errors(errors, read_count, bool(self.log_directory))
             self.bitflip_found = True
-            return
+            return errors_in_rows
 
     def payload_executor_attack(self, read_count, row_tuple):
         """

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -168,7 +168,7 @@ class RowHammer:
             memfill(self.wb, n, pattern=row_patterns[row], base=base, burst=255)
             if row % row_progress == 0:
                 print('.', end='', flush=True)
-            # makes sure to synchronize with the writes (without it for slower conenction
+            # makes sure to synchronize with the writes (without it for slower connection
             # we may have a timeout on the first read after writing)
             self.wb.regs.ctrl_scratch.read()
 

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -16,6 +16,12 @@ from rowhammer_tester.scripts.playbook.lib import (generate_payload_from_row_lis
 
 
 class RowHammer:
+    """
+    Base class for running rowhammer attacks.
+    It uses wishbone bridge connection to write patterns to the memory.
+
+    Other classes can inherit from this class to change attack method.
+    """
 
     def __init__(
             self,
@@ -41,9 +47,15 @@ class RowHammer:
 
     @property
     def rows(self):
+        """
+        Read only list of rows to attack.
+        """
+
         return list(range(self.rows_start, self.rows_start + self.nrows))
 
     def addresses_per_row(self, row):
+        """Returns a list of column addresses for a given row"""
+
         # Calculate the addresses lazily and cache them
         if row not in self._addresses_per_row:
             addresses = [
@@ -54,6 +66,16 @@ class RowHammer:
         return self._addresses_per_row[row]
 
     def attack(self, row_tuple, read_count, progress_header=''):
+        """
+        Performs the actual attack.
+        Uses *rowhammer*tester/gateware/rowhammer.py* underneath to perform reads via the DMA.
+
+        ``row_tuple`` is a pair of rows to be hammered (attacked row is between them)
+        ``row_count`` is divided between hammered rows, so specifying ``read_count = 2e5`` means,
+        that each row will be hammered ``1e5`` times
+        """
+        # FIXME: describe what progress_header does
+
         # Make sure that the Rowhammer module is in reset state
         self.wb.regs.rowhammer_enabled.write(0)
         self.wb.regs.rowhammer_count.read()  # clears the value
@@ -77,6 +99,7 @@ class RowHammer:
                 row_tuple, count / 1e6, read_count / 1e6, n=row_strw)
             print(s, end='  \r')
 
+        # Wait for hammering to finish
         while True:
             count = self.wb.regs.rowhammer_count.read()
             progress(count)
@@ -88,6 +111,16 @@ class RowHammer:
         print()
 
     def row_access_iterator(self, burst=16):
+        """
+        Generates a sequence of tuples of three:
+
+        0. row number
+        1. number of 32-bit words in a row
+        2. address of first word in a row
+
+        Sequence is generated only for rows in ``self.rows`` list, so rows to attack.
+        """
+
         for row in self.rows:
             addresses = self.addresses_per_row(row)
             n = (max(addresses) - min(addresses)) // 4
@@ -95,6 +128,12 @@ class RowHammer:
             yield row, n, base_addr
 
     def check_errors(self, row_patterns, row_progress=16):
+        """
+        Checks errors in rows from ``self.rows`` list.
+        This means, that if any row had bitflips, but wasn't a target,
+        there would be no error checks for it.
+        """
+
         row_errors = {}
         for row, n, base in self.row_access_iterator():
             errors = memcheck(self.wb, n, pattern=row_patterns[row], base=base, burst=255)
@@ -104,23 +143,33 @@ class RowHammer:
         return row_errors
 
     def errors_count(self, row_errors):
+        """Counts number of rows with bitflips."""
+
         return sum(1 if len(e) > 0 else 0 for e in row_errors.values())
 
     @staticmethod
     def bitcount(x):
+        """Counts set bits in ``x``."""
+
         return bin(x).count('1')  # seems faster than operations on integers
 
     @classmethod
     def bitflips(cls, val, ref):
+        """Counts differing bits between ``val`` and ``ref``."""
+
         return cls.bitcount(val ^ ref)
 
     def errors_bitcount(self, row_errors):
+        """Counts number of differing bits in rows from ``row_errors``."""
+
         return sum(
             sum(self.bitflips(value, expected)
                 for addr, value, expected in e)
             for e in row_errors.values())
 
     def display_errors(self, row_errors, read_count, do_error_summary=False):
+        # FIXME: add docstring
+
         err_dict = {}
         for row in row_errors:
             cols = []
@@ -156,6 +205,15 @@ class RowHammer:
             return err_dict
 
     def run(self, row_pairs, pattern_generator, read_count, row_progress=16, verify_initial=False):
+        """
+        Main part of the script.
+        First fills the memory with specified patterns, then optionally checks its integrity.
+        It disables refreshes if requested.
+        Next it executes the attack, one row pair at a time.
+        If refreshes were disabled, it reenables them.
+        It checks for errors, and if any were found, displays them.
+        """
+
         # TODO: need to invert data when writing/reading, make sure Python integer inversion works correctly
         if self.data_inversion:
             raise NotImplementedError('Currently only HW rowhammer supports data inversion')
@@ -210,6 +268,10 @@ class RowHammer:
             return
 
     def payload_executor_attack(self, read_count, row_tuple):
+        """
+        Performs the attack using payload executor
+        """
+
         sys_clk_freq = float(get_generated_defs()['SYS_CLK_FREQ'])
         payload = generate_payload_from_row_list(
             read_count=read_count,
@@ -229,14 +291,17 @@ class RowHammer:
 
 
 def patterns_const(rows, value):
+    """Same pattern for each row."""
     return {row: value for row in rows}
 
 
 def patterns_alternating_per_row(rows):
+    """Even rows all 1's, odd rows all 0's."""
     return {row: 0xffffffff if row % 2 == 0 else 0x00000000 for row in rows}
 
 
 def patterns_random_per_row(rows, seed=42):
+    """Random pattern per row."""
     rng = random.Random(seed)
     return {row: rng.randint(0, 2**32 - 1) for row in rows}
 

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -376,11 +376,10 @@ def main(row_hammer_cls):
     args = parser.parse_args()
 
     if args.read_count and args.read_count_range:
-        print("--read_count and --read_count_range are mutually exclusive - choose one or another.")
-        sys.exit(2)
+        parser.error(
+            "--read_count and --read_count_range are mutually exclusive - choose one or another.")
     if args.all_rows and args.row_pairs:
-        print("--all-rows and --row-pairs are mutually exclusive - choose one or another.")
-        sys.exit(2)
+        parser.error("--all-rows and --row-pairs are mutually exclusive - choose one or another.")
 
     if args.experiment_no == 1:
         args.nrows = 512
@@ -426,8 +425,9 @@ def main(row_hammer_cls):
         def rand_row():
             return rng.randint(args.start_row, args.start_row + args.nrows)
 
-        assert not (
-            args.row_pairs == 'const' and not args.const_rows_pair), 'Specify --const-rows-pair'
+        if args.row_pairs == 'const' and not args.const_rows_pair:
+            parser.error('Using --row-pairs=const requires specifying --const-rows-pair.')
+
         if args.row_pairs:
             row_pairs = {
                 'sequential': [(0 + args.start_row, i + args.start_row) for i in range(args.nrows)],

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -337,7 +337,7 @@ def main(row_hammer_cls):
     parser.add_argument(
         '--const-rows-pair',
         type=int,
-        nargs='+',
+        nargs=2,
         required=False,
         help='When using --row-pairs constant')
     parser.add_argument(

--- a/rowhammer_tester/targets/common.py
+++ b/rowhammer_tester/targets/common.py
@@ -405,8 +405,8 @@ def get_sdram_module(name):
     if upstream is None and local is None:
         raise RuntimeError(f'Could not find module {name}')
     if upstream is not None and local is not None:
-        log.warning(f'Module {name} defined both in LiteDRAM and in litex-rowhammer-tester!'
-            ' Consider removing the definition in litex-rowhammer-tester.')
+        log.warning(f'Module {name} defined both in LiteDRAM and in rowhammer-tester!'
+            ' Consider removing the definition in rowhammer-tester.')
     if local is not None:
         log.warning(f'Using module {name} defined locally. Should be moved to LiteDRAM.')
         module = local


### PR DESCRIPTION
Added docstrings for `RowHammer` class and its methods.
Fixed some typos and bugs, as in title.

Last commit (pattern generation fix) also allows to hammer single row.
By using command below, one can hammer only row 31, 100 000 times.

```
python rowhammer_tester/scripts/hw_rowhammer.py --payload-executor --no-refresh --row-pairs const --const-rows-pair 31 31 --read_count 1e5
```

`hw_rowhammer.py` script must be used, as it fills and checks entire memory for bitflips, where non-hw version doesn't.
Payload executor is required as it bypasses DMA, which wouldn't deactivate row.