### PR TITLE
Add scripts for visualizing attack results from logs

### DIFF
--- a/doc/general.rst
+++ b/doc/general.rst
@@ -459,6 +459,27 @@ Start a simple HTTP server inside the production directory: ::
   python -m http.server 8080
 
 
+logs2dq.py
+~~~~~~~~~~~
+
+This script allows you to visualize bitflips and group them per DQ pad.
+Pads themselves are grouped using colors to differentiate modules.
+Using this script you can visualize and check which module is failing the most.
+
+By default it shows you mean bitflips across all attacks with standard deviation.
+
+First run ``rowhammer.py`` or ``hw_rowhammer.py`` with ``--log-dir log_directory``
+
+Then run: ::
+
+  python3 logs2dq.py log_directory/your_error_summary.json
+
+You can also pass optional arguments:
+
+* ``--dq DQ`` - how many pads are connected to one module
+* ``--per-attack`` - allows you to also view DQ groupings for each attacked pair of rows
+
+
 Other scripts
 ^^^^^^^^^^^^^
 

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -433,6 +433,32 @@ You can control number of displayed columns with ``--plot-columns``.
 For example if your module has 1024 columns and you provide ``--plot-columns 16``, then DRAM columns will be displayed in groups of 64.
 
 
+logs2vis.py
+~~~~~~~~~~~
+
+Similarly to ``logs2plot.py``, you can generate visualization using `F4PGA Database Visualizer <https://github.com/chipsalliance/f4pga-database-visualizer>`_.
+
+To view results using DB Visualizer you need to:
+
+Clone and build the visualizer with: ::
+
+    git clone https://github.com/chipsalliance/f4pga-database-visualizer
+    cd f4pga-database-visualizer
+    npm run build
+
+Run ``rowhammer.py`` or ``hw_rowhammer.py`` with ``--log-dir log_directory``
+
+Generate JSON files for the visualizer: ::
+
+  python3 logs2vis.py log_directory/your_error_summary.json vis_directory
+
+Copy generated JSON files from ``vis_directory`` to ``/path/to/f4pga-database-visualizer/dist/production/``
+
+Start a simple HTTP server inside the production directory: ::
+
+  python -m http.server 8080
+
+
 Other scripts
 ^^^^^^^^^^^^^
 

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -223,8 +223,8 @@ For the complete list of modifiers, see ``--help``.
 
 There are also two versions of a rowhammer script:
 
-* ``rowhammer.py`` - this one uses Processing System to fill/check the memory
-* ``hw_rowhammer.py`` - BIST blocks will be used to fill/check the memory
+* ``rowhammer.py`` - this one uses regular memory access via EtherBone to fill/check the memory (slower)
+* ``hw_rowhammer.py`` - BIST blocks will be used to fill/check the memory (much faster, but with some limitations regarding fill pattern)
 
 BIST blocks are faster and are the intended way of running Row Hammer Tester.
 

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -413,6 +413,26 @@ Perform set of tests for different read count values in a given range for a sequ
   (venv) $ python hw_rowhammer.py --pattern 01_in_row --row-pairs sequential --start-row 40 --nrows 512 --no-refresh --read_count_range 10e4 10e5 20e4
 
 
+logs2plot.py
+~~~~~~~~~~~
+
+There is an option to plot a graph showing distribution of bitflips across rows and columns from generated logs.
+For example one can generate graphs by calling: ::
+
+  (venv) $ python logs2plot.py your_error_summary.json
+
+For every attack there will be one graph.
+So if you attacked two row pairs ``(A, B)``, ``(C, D)`` with two different read counts each ``(X, Y)``, for a total of 4 attacks, there will be 4 plots generated:
+
+* read count: ``X`` and pair: ``(A, B)``
+* read count: ``X`` and pair: ``(C, D)``
+* read count: ``Y`` and pair: ``(A, B)``
+* read count: ``Y`` and pair: ``(C, D)``
+
+You can control number of displayed columns with ``--plot-columns``.
+For example if your module has 1024 columns and you provide ``--plot-columns 16``, then DRAM columns will be displayed in groups of 64.
+
+
 Other scripts
 ^^^^^^^^^^^^^
 

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -113,12 +113,12 @@ Expected output:
     Payload per-row toggle count = 0.010K  x10 rows
     Payload refreshes (if enabled) = 10 (disabled)
     Expected execution time = 1903 cycles = 0.019 ms
-  
+
   Transferring the payload ...
-  
+
   Executing ...
   Time taken: 0.738 ms
-  
+
   Progress: [==                                      ]  3338 / 65536 (Errors: 1287)
   ...
 
@@ -165,7 +165,7 @@ Expected output:
 
 .. code-block:: console
 
-  Progress: [========================================] 3072 / 3072 
+  Progress: [========================================] 3072 / 3072
   Generating payload:
     tRAS = 5
     tRP = 3
@@ -177,13 +177,13 @@ Expected output:
     Payload per-row toggle count = 0.010K  x2 rows
     Payload refreshes (if enabled) = 10 (disabled)
     Expected execution time = 1263 cycles = 0.013 ms
-  
+
   Transferring the payload ...
-  
+
   Executing ...
   Time taken: 0.647 ms
-  
-  Progress: [============                            ]  323 / 1024 (Errors: 320) 
+
+  Progress: [============                            ]  323 / 1024 (Errors: 320)
   ...
 
 HalfDoubleAnalysisPayloadGenerator

--- a/rowhammer_tester/scripts/logs2dq.py
+++ b/rowhammer_tester/scripts/logs2dq.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+This script generates plots from rowhammer attack logs using matplotlib
+Each attack is a separate plot representing bitflips grouped per DQ pad.
+Bars represent DQ pads and are colored to differentiate modules.
+"""
+
+import argparse
+import json
+
+from pathlib import Path
+from matplotlib import pyplot as plt
+import numpy as np
+
+DQ_PADS = 64
+DQ_RATIO = 4
+
+
+def plot(values: np.ndarray, stderror: np.ndarray = None, title=""):
+    """Show plot with DQ pads grouped per module"""
+    modules = int(DQ_PADS / DQ_RATIO)
+
+    plt.xlabel("DQ pad")
+    plt.xticks(list(range(0, DQ_PADS, DQ_RATIO)) + [DQ_PADS - 1])
+    plt.ylabel("Bitflips")
+
+    for m in range(modules):
+        start, end = DQ_RATIO * m, DQ_RATIO * (m + 1)
+        yerr = stderror[start:end] if stderror is not None else stderror
+        plt.bar(range(start, end), values[start:end], yerr=yerr)
+
+    plt.title(title)
+
+    plt.show()
+
+
+def count_bitflips_per_dq(data: dict):
+    """Count bitflips per DQ pad in data from a single attack"""
+    counts = np.zeros(DQ_PADS)
+
+    for _, row_errors in data["errors_in_rows"].items():
+        for _, single_read in row_errors["col"].items():
+            for bitflip in single_read:
+                counts[bitflip % DQ_PADS] += 1
+
+    return counts
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log_file", help="file with log output")
+    parser.add_argument("--per-attack", action="store_true", help="show plot for each attack")
+    parser.add_argument("--dq", default=4, type=int, help="DQ to DQS ratio")
+    args = parser.parse_args()
+
+    DQ_RATIO = args.dq
+
+    log_file = Path(args.log_file)
+    with log_file.open() as fd:
+        log_data = json.load(fd)
+
+    all_dq_counters = np.zeros((0, DQ_PADS))
+    # read_count / read_count_range level
+    for read_count, attack_set_results in log_data.items():
+        # remove read_count as it's only interrupting here
+        if "read_count" in attack_set_results:
+            attack_set_results.pop("read_count")
+
+        # pair hammering level
+        for pair, attack_results in attack_set_results.items():
+            dq_counters = count_bitflips_per_dq(attack_results)
+            if args.per_attack:
+                hammered_rows = (attack_results["hammer_row_1"], attack_results["hammer_row_2"])
+                plot(dq_counters, title=f"Hammered rows {hammered_rows}")
+            all_dq_counters = np.append(all_dq_counters, [dq_counters], axis=0)
+
+    all_mean = all_dq_counters.mean(axis=0)
+    all_stdev = all_dq_counters.std(axis=0)
+    plot(all_mean, all_stdev, "Mean bitflips across all attacks")

--- a/rowhammer_tester/scripts/logs2dq.py
+++ b/rowhammer_tester/scripts/logs2dq.py
@@ -66,12 +66,18 @@ if __name__ == "__main__":
         if "read_count" in attack_set_results:
             attack_set_results.pop("read_count")
 
-        # pair hammering level
-        for pair, attack_results in attack_set_results.items():
+        # single attack level
+        for attack, attack_results in attack_set_results.items():
             dq_counters = count_bitflips_per_dq(attack_results)
             if args.per_attack:
-                hammered_rows = (attack_results["hammer_row_1"], attack_results["hammer_row_2"])
-                plot(dq_counters, title=f"Hammered rows {hammered_rows}")
+                if attack.startswith("pair"):
+                    hammered_rows = (attack_results["hammer_row_1"], attack_results["hammer_row_2"])
+                    title = f"Hammered rows: {hammered_rows}"
+                elif attack.startswith("sequential"):
+                    start_row = attack_results["row_pairs"][0][1]
+                    end_row = attack_results["row_pairs"][-1][1]
+                    title = f"Sequential attack on rows from {start_row} to {end_row}"
+                plot(dq_counters, title=title)
             all_dq_counters = np.append(all_dq_counters, [dq_counters], axis=0)
 
     all_mean = all_dq_counters.mean(axis=0)

--- a/rowhammer_tester/scripts/logs2plot.py
+++ b/rowhammer_tester/scripts/logs2plot.py
@@ -17,7 +17,7 @@ import numpy as np
 from rowhammer_tester.scripts.utils import get_generated_file
 
 
-def plot(data: dict, _rows: int, cols: int, col_step=32):
+def plot(data: dict, _rows: int, cols: int, col_step=32, title=""):
     affected_rows_count = len(data["errors_in_rows"])
 
     # row_labels correspond to actual row numbers, but row_vals
@@ -59,9 +59,7 @@ def plot(data: dict, _rows: int, cols: int, col_step=32):
     ticks_step = max(1, int(max_errors // 20))
     plt.colorbar(ticks=range(0, max_errors + 1, ticks_step))
 
-    hammered_rows = (data["hammer_row_1"], data["hammer_row_2"])
-    plt.title(f"Hammered rows {hammered_rows}")
-
+    plt.title(title)
     plt.show()
 
 
@@ -90,11 +88,20 @@ if __name__ == "__main__":
         if "read_count" in attack_set_results:
             attack_set_results.pop("read_count")
 
-        # pair hammering level
-        for pair, attack_results in attack_set_results.items():
+        # single attack level
+        for attack, attack_results in attack_set_results.items():
+            if attack.startswith("pair"):
+                hammered_rows = (attack_results["hammer_row_1"], attack_results["hammer_row_2"])
+                title = f"Hammered rows: {hammered_rows}"
+            elif attack.startswith("sequential"):
+                start_row = attack_results["row_pairs"][0][1]
+                end_row = attack_results["row_pairs"][-1][1]
+                title = f"Sequential attack on rows from {start_row} to {end_row}"
+
             plot(
                 attack_results,
                 ROWS,
                 COLS,
                 COLS // args.plot_columns,
+                title=title,
             )

--- a/rowhammer_tester/scripts/logs2plot.py
+++ b/rowhammer_tester/scripts/logs2plot.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+This script generates plots from rowhammer attack logs using matplotlib
+Each attack is a separate plot
+"""
+
+import os
+import argparse
+import json
+
+from pathlib import Path
+from matplotlib import cm
+from matplotlib import colors
+from matplotlib import pyplot as plt
+import numpy as np
+
+from rowhammer_tester.scripts.utils import get_generated_file
+
+
+def plot(data: dict, _rows: int, cols: int, col_step=32):
+    affected_rows_count = len(data["errors_in_rows"])
+
+    # row_labels correspond to actual row numbers, but row_vals
+    # start from 0, to prevent displaying rows between them
+    row_labels: list[str] = []
+    row_vals: list[int] = []
+
+    # cols_vals are normal column numbers
+    col_vals: list[int] = []
+
+    for i, (row, row_errors) in enumerate(data["errors_in_rows"].items()):
+        row_labels.append(row)
+        for col, col_errors in row_errors["col"].items():
+            for _ in col_errors:
+                row_vals.append(i)
+                col_vals.append(int(col))
+
+    bins = [range(0, cols + 1, col_step), np.arange(min(row_vals) - 0.5, max(row_vals) + 1, 1)]
+
+    # custom cmap with white color for 0
+    custom_cmap = colors.ListedColormap(["white", *cm.get_cmap("viridis").colors])
+
+    h, _, _, _ = plt.hist2d(
+        col_vals,
+        row_vals,
+        bins=bins,
+        range=[[0, cols // col_step], [min(row_vals), max(row_vals)]],
+        cmap=custom_cmap)
+
+    plt.xlabel('Column')
+    plt.xticks(range(0, cols + 1, col_step))
+
+    plt.ylabel('Row')
+    plt.yticks(range(affected_rows_count), row_labels)
+
+    # limit number of colorbar ticks
+    # if left unchanged they can be floats, which looks bad
+    max_errors = int(h.max())
+    ticks_step = max(1, int(max_errors // 20))
+    plt.colorbar(ticks=range(0, max_errors + 1, ticks_step))
+
+    hammered_rows = (data["hammer_row_1"], data["hammer_row_2"])
+    plt.title(f"Hammered rows {hammered_rows}")
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log_file", help="file with log output")
+    parser.add_argument(
+        "--plot-columns", type=int, default=32, help="how many columns to show in resulting grid")
+    # TODO: add option to save plots to files without showing GUI
+    args = parser.parse_args()
+
+    settings_file = Path(get_generated_file("litedram_settings.json"))
+    with settings_file.open() as fd:
+        settings = json.load(fd)
+
+    COLS = 2**settings["geom"]["colbits"]
+    ROWS = 2**settings["geom"]["rowbits"]
+
+    log_file = Path(args.log_file)
+    with log_file.open() as fd:
+        log_data = json.load(fd)
+
+    # read_count / read_count_range level
+    for read_count, attack_set_results in log_data.items():
+        # remove read_count as it's only interrupting here
+        if "read_count" in attack_set_results:
+            attack_set_results.pop("read_count")
+
+        # pair hammering level
+        for pair, attack_results in attack_set_results.items():
+            plot(
+                attack_results,
+                ROWS,
+                COLS,
+                COLS // args.plot_columns,
+            )

--- a/rowhammer_tester/scripts/logs2vis.py
+++ b/rowhammer_tester/scripts/logs2vis.py
@@ -71,15 +71,16 @@ def get_vis_data(data: dict, rows: int, cols: int, col_step: int = 32) -> tuple[
                     desc,
                 ])
 
-    for row in (data["hammer_row_1"], data["hammer_row_2"]):
-        # hammered row could have been at one of the ends
-        if row < first_row:
-            first_row = row
-        if row > last_row:
-            last_row = row
+    if "hammer_row_1" in data and "hammer_row_2" in data:
+        for row in (data["hammer_row_1"], data["hammer_row_2"]):
+            # hammered row could have been at one of the ends
+            if row < first_row:
+                first_row = row
+            if row > last_row:
+                last_row = row
 
-        # add "TGT" cells for rows that were hammered
-        vis_data.append([0, row, cols // col_step, "TGT", "Target", "Target row", []])
+            # add "TGT" cells for rows that were hammered
+            vis_data.append([0, row, cols // col_step, "TGT", "Target", "Target row", []])
 
     return vis_data, first_row, last_row
 

--- a/rowhammer_tester/scripts/logs2vis.py
+++ b/rowhammer_tester/scripts/logs2vis.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+This script generates visualization from rowhammer attack logs using F4PGA Database Visualizer
+Each attack is a separate visualization
+"""
+
+import os
+import argparse
+import json
+import datetime
+
+from pathlib import Path
+
+from rowhammer_tester.scripts.utils import get_generated_file
+
+
+def get_vis_data(data: dict, rows: int, cols: int, col_step: int = 32) -> tuple[list, int, int]:
+    """
+    Generates ``vis_data``, which is a list of cell descriptions
+    Each cell is a list of parameters:
+        col: int
+        row: int
+        width: int
+        type: str
+        label: str
+        title: str
+        description: list
+    """
+
+    vis_data = []
+
+    first_row: int = rows - 1
+    last_row: int = 0
+    for row_errors in data["errors_in_rows"].values():
+        row = row_errors["row"]
+
+        # we keep track of first and last row,
+        # to limit the number of displayed rows
+        if row < first_row:
+            first_row = row
+        if row > last_row:
+            last_row = row
+
+        for col in range(0, cols, col_step):
+            desc: list = ["# Bits affected"]
+
+            flips_in_chunk = 0
+            for i in range(col_step):
+                col_str = str(col + i)
+                col_errors = row_errors["col"].get(col_str, [])
+
+                flips_in_chunk += len(col_errors)
+                if len(col_errors):
+                    desc.append({f"Column {col_str}": f"{col_errors}"})
+
+            if flips_in_chunk > 0:
+                cell_type = "FLIP"
+                cell_label = str(flips_in_chunk)
+            else:
+                cell_type = "OK"
+                cell_label = "OK"
+
+            vis_data.append(
+                [
+                    col // col_step,
+                    row,
+                    1,
+                    cell_type,
+                    cell_label,
+                    f"Columns {col} to {col+col_step-1}",
+                    desc,
+                ])
+
+    for row in (data["hammer_row_1"], data["hammer_row_2"]):
+        # hammered row could have been at one of the ends
+        if row < first_row:
+            first_row = row
+        if row > last_row:
+            last_row = row
+
+        # add "TGT" cells for rows that were hammered
+        vis_data.append([0, row, cols // col_step, "TGT", "Target", "Target row", []])
+
+    return vis_data, first_row, last_row
+
+
+def get_vis_config(entries: list[Path]) -> dict[str, list[dict[str, str]]]:
+    return {
+        'dataFilesList': [{
+            "name": e.stem,
+            "url": e.name
+        } for e in entries],
+    }
+
+
+def get_vis_metadata(first_row: int, last_row: int, cols: int, data_file: str):
+    return {
+        'buildDate': datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+        'grids': {
+            'rowhammer': {
+                'name': 'Rowhammer',
+                'colsRange': cols - 1,
+                'rowsRange': [first_row, last_row],
+                'cells': {
+                    'fieldOrder':
+                    ['col', 'row', 'width', 'type', 'name', 'fullName', 'description'],
+                    'fieldTemplates': {
+                        'color': '{get(COLORS, type)}'
+                    },
+                    'templateConsts': {
+                        'COLORS': {
+                            'OK': 19,
+                            'FLIP': 1,
+                            'TGT': 3
+                        }
+                    },
+                    'data': {
+                        '@import': data_file
+                    }
+                }
+            }
+        }
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log_file", help="file with log output")
+    parser.add_argument("vis_dir", help="directory where to put visualization json files")
+    parser.add_argument(
+        "--vis-columns", type=int, default=32, help="how many columns to show in resulting grid")
+    args = parser.parse_args()
+
+    # get module settings to calculate total number of rows and columns
+    settings_file = Path(get_generated_file("litedram_settings.json"))
+    with settings_file.open() as fd:
+        settings = json.load(fd)
+
+    COLS = 2**settings["geom"]["colbits"]
+    ROWS = 2**settings["geom"]["rowbits"]
+
+    log_file = Path(args.log_file)
+    with log_file.open() as fd:
+        log_data = json.load(fd)
+
+    vis_dir = Path(args.vis_dir).resolve()
+    vis_dir.mkdir(parents=True, exist_ok=True)
+
+    # list of meta file names
+    # only files listed in viewer config can be browsed
+    meta_files: list[Path] = []
+
+    # read_count / read_count_range level
+    for read_count, attack_set_results in log_data.items():
+        # remove read_count as it's only interrupting here
+        if "read_count" in attack_set_results:
+            attack_set_results.pop("read_count")
+
+        # pair hammering level
+        for pair, attack_results in attack_set_results.items():
+            output_name = f"{read_count}_{pair}"
+
+            # generate visualization data from logs of hammering
+            # a single pair of rows
+            vis_data, first_row, last_row = get_vis_data(
+                attack_results,
+                ROWS,
+                COLS,
+                COLS // args.vis_columns,
+            )
+            # write data file
+            data_file = (vis_dir / output_name).with_suffix(".data.json")
+            with data_file.open("w") as fd:
+                json.dump(vis_data, fd)
+
+            vis_meta = get_vis_metadata(first_row, last_row, args.vis_columns, data_file.name)
+            # write meta file
+            meta_file = (vis_dir / output_name).with_suffix(".json")
+            meta_files.append(meta_file)
+            with meta_file.open("w") as fd:
+                json.dump(vis_meta, fd)
+
+    # write config file
+    vis_config = get_vis_config(meta_files)
+    config_file = vis_dir / "sdbv.config.json"
+    with config_file.open("w") as fd:
+        json.dump(vis_config, fd)

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -34,7 +34,6 @@ class RowHammer:
             rows_start=0,
             no_refresh=False,
             verbose=False,
-            plot=False,
             payload_executor=False,
             data_inversion=False):
         for name, val in locals().items():
@@ -200,15 +199,6 @@ class RowHammer:
             if do_error_summary:
                 err_dict["{}".format(row)] = {'row': _row, 'col': cols, 'bitflips': flips}
 
-        if self.plot:
-            from matplotlib import pyplot as plt
-            row_err_counts = [len(row_errors.get(row, [])) for row in self.rows]
-            plt.bar(self.rows, row_err_counts, width=1)
-            plt.grid(True)
-            plt.xlabel('Row')
-            plt.ylabel('Errors')
-            plt.show()
-
         if do_error_summary:
             return err_dict
 
@@ -370,9 +360,6 @@ def main(row_hammer_cls):
         required=False,
         help='Jump between rows when using --all-rows')
     parser.add_argument(
-        '--plot', action='store_true',
-        help='Plot errors distribution')  # requiers matplotlib and pyqt5 packages
-    parser.add_argument(
         '--payload-executor',
         action='store_true',
         help='Do the attack using Payload Executor (1st row only)')
@@ -464,7 +451,6 @@ def main(row_hammer_cls):
         bank=args.bank,
         rows_start=args.start_row,
         verbose=args.verbose,
-        plot=args.plot,
         no_refresh=args.no_refresh,
         payload_executor=args.payload_executor,
         data_inversion=args.data_inversion,

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -167,12 +167,19 @@ class RowHammer:
                 for addr, value, expected in e)
             for e in row_errors.values())
 
+    @staticmethod
+    def bitflip_list(val, exp):
+        # FIXME: add docstring
+
+        expr = f'{val ^ exp:#0{len(bin(exp))}b}'
+        return [i for i, c in enumerate(expr[2:]) if c == '1']
+
     def display_errors(self, row_errors, read_count, do_error_summary=False):
         # FIXME: add docstring
 
         err_dict = {}
         for row in row_errors:
-            cols = []
+            cols = {}
             if len(row_errors[row]) > 0:
                 flips = sum(
                     self.bitflips(value, expected) for addr, value, expected in row_errors[row])
@@ -188,7 +195,8 @@ class RowHammer:
                         print(
                             "Error: 0x{:08x}: 0x{:08x} (row={}, col={})".format(
                                 addr, word, _row, col))
-                    cols.append(col)
+                    bitflips = self.bitflip_list(word, expected)
+                    cols[col] = bitflips
             if do_error_summary:
                 err_dict["{}".format(row)] = {'row': _row, 'col': cols, 'bitflips': flips}
 


### PR DESCRIPTION
This PR is based on #69 and supersedes it.
Instead of overloading `rowhammer.py`, it extracts code used for generating plots and visualizations into separate scripts.

I had to extend generated logs a little bit to allow producing the same kinds of visualizations as in #69.
This allows visualizing on demand instead of only after an attack.