### PR TITLE
Visualize bit flips in rows by amount in relation to aggresor row

### DIFF
--- a/doc/general.rst
+++ b/doc/general.rst
@@ -422,23 +422,36 @@ Perform set of tests for different read count values in a given range for a sequ
 
 
 logs2plot.py
-~~~~~~~~~~~
+~~~~~~~~~~~~
 
-There is an option to plot a graph showing distribution of bitflips across rows and columns from generated logs.
-For example one can generate graphs by calling: ::
+This script is capable of plotting graphs out of generated logs. It can generate two different types of graphs:
 
-  (venv) $ python logs2plot.py your_error_summary.json
 
-For every attack there will be one graph.
-So if you attacked two row pairs ``(A, B)``, ``(C, D)`` with two different read counts each ``(X, Y)``, for a total of 4 attacks, there will be 4 plots generated:
+#.
+   Distribution of bitflips across rows and columns. For example one can generate graphs by calling: ::
 
-* read count: ``X`` and pair: ``(A, B)``
-* read count: ``X`` and pair: ``(C, D)``
-* read count: ``Y`` and pair: ``(A, B)``
-* read count: ``Y`` and pair: ``(C, D)``
+      (venv) $ python logs2plot.py your_error_summary.json
 
-You can control number of displayed columns with ``--plot-columns``.
-For example if your module has 1024 columns and you provide ``--plot-columns 16``, then DRAM columns will be displayed in groups of 64.
+   For every attack there will be one graph.
+   So if you attacked two row pairs ``(A, B)``, ``(C, D)`` with two different read counts each ``(X, Y)``, for a total of 4 attacks, there will be 4 plots generated:
+
+   * read count: ``X`` and pair: ``(A, B)``
+   * read count: ``X`` and pair: ``(C, D)``
+   * read count: ``Y`` and pair: ``(A, B)``
+   * read count: ``Y`` and pair: ``(C, D)``
+
+   You can control number of displayed columns with ``--plot-columns``.
+   For example if your module has 1024 columns and you provide ``--plot-columns 16``, then DRAM columns will be displayed in groups of 64.
+
+
+#.
+   Distribution of rows affected by bitflips due to targetting single rows. For example one can generate a graph by calling: ::
+
+      (venv) $ python logs2plot.py --aggressors-vs-victims your_error_summary.json
+
+   There will be one graph generated that will show victims on X axis and aggressors on Y axis. Tiles' colors indicate how many bitflips occured on each victim.
+
+   You can enable additional annotation with ``--annotate bitflips`` so that number of occured bitflips will be explicitly labeled on top of each victim tile.
 
 
 logs2vis.py


### PR DESCRIPTION
This PR adds support for plotting graphs to visualize which rows are affected by attacking single rows. It plots a graph with victims on X axis and aggressors on Y axis, tiles' colors correspond to amount of flipped bits. It also allows enabling labels with amount of bitflips that occured for specific rows.

Examples of outputs graphs after hammering 100 single rows with 100000 reads:
```bash
python hw_rowhammer.py --all-rows --nrows 100 --row-pair-distance 0 --payload-executor --no-refresh --read_count 1e5
```

1. Graph without annotations:
```bash
python logs2plot.py --aggressors-vs-victims logs.json
```
![no_annotation](https://user-images.githubusercontent.com/39563896/189946799-058f683d-bbe7-4599-bc30-b7c380c8039c.png)

2. Graph with annotations:
```bash
python logs2plot.py --annotate bitflips --aggressors-vs-victims logs.json
```
![annotation](https://user-images.githubusercontent.com/39563896/189946869-fbf1c517-e9a7-4cd7-b449-61780e98d9c1.png)
![annotation_zoomed](https://user-images.githubusercontent.com/39563896/189946885-d982be69-8d70-4cd1-85d7-757fa69414c8.png)
