### PR TITLE
Generate DQ graphs for single aggressor vs victim log on mouse click

### DIFF
--- a/rowhammer_tester/scripts/logs2dq.py
+++ b/rowhammer_tester/scripts/logs2dq.py
@@ -25,9 +25,10 @@ def plot(
     """Show plot with DQ pads grouped per module"""
     modules = int(DQ_PADS / DQ_RATIO)
 
-    plt.xlabel("DQ pad")
-    plt.xticks(list(range(0, DQ_PADS, DQ_RATIO)) + [DQ_PADS - 1])
-    plt.ylabel("Bitflips")
+    fig, ax = plt.subplots()
+    ax.set_xlabel("DQ pad")
+    ax.set_xticks(list(range(0, DQ_PADS, DQ_RATIO)) + [DQ_PADS - 1])
+    ax.set_ylabel("Bitflips")
 
     for m in range(modules):
         start, end = DQ_RATIO * m, DQ_RATIO * (m + 1)
@@ -41,14 +42,14 @@ def plot(
         else:
             yerr = None
 
-        plt.bar(x, y, yerr=yerr)
+        ax.bar(x, y, yerr=yerr)
 
     if log_scale:
-        plt.yscale("log")
+        ax.set_yscale("log")
 
-    plt.title(title)
+    ax.set_title(title)
 
-    plt.show()
+    fig.show()
 
 
 def count_bitflips_per_dq(data: dict):


### PR DESCRIPTION
This adds a feature to open a new plot in new window that shows which DQs are affected by bitflips on a single aggressor vs victim attack log. New plots are opened each time user presses left mouse button on a tile that contains some logs. This will have no effect when pressed on empty tile or out of a graph bounds.

It works only for graphs that are generated for aggressors vs victims relations and it doesn't affect other variants.

Example of how it looks like:
![dqs_vict_vs_aggr](https://user-images.githubusercontent.com/39563896/191063620-dc3adacc-457e-4692-b8b4-f88d1fd762d4.png)
