### PR TITLE
submodules: Use Antmicro's Litex fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/enjoy-digital/litescope.git
 [submodule "litex"]
 	path = third_party/litex
-	url = https://github.com/enjoy-digital/litex.git
+	url = https://github.com/antmicro/litex.git
 [submodule "migen"]
 	path = third_party/migen
 	url = https://github.com/m-labs/migen


### PR DESCRIPTION
This PR uses Antmicro's fork of Litex with some changes to litex client and server classes, which use EtherBone, aiming at adding verbosity and resilience of the UDP connection.