### PR TITLE
Read ident

### DIFF
--- a/rowhammer_tester/scripts/analyzer.py
+++ b/rowhammer_tester/scripts/analyzer.py
@@ -5,7 +5,7 @@ import argparse
 
 from litescope.software.litescope_cli import *
 
-from rowhammer_tester.scripts.utils import RemoteClient, get_generated_file
+from rowhammer_tester.scripts.utils import RemoteClient, get_generated_file, read_ident
 
 # Wrapper around litescope_cli
 if __name__ == "__main__":
@@ -19,6 +19,7 @@ if __name__ == "__main__":
 
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     try:
         analyzer = LiteScopeAnalyzerDriver(wb.regs, "analyzer", debug=True)

--- a/rowhammer_tester/scripts/benchmark.py
+++ b/rowhammer_tester/scripts/benchmark.py
@@ -6,7 +6,7 @@ import cProfile
 
 import argparse
 
-from rowhammer_tester.scripts.utils import memread, memwrite, hw_memset, hw_memtest, RemoteClient
+from rowhammer_tester.scripts.utils import memread, memwrite, hw_memset, hw_memtest, RemoteClient, read_ident
 
 
 def human_size(num):
@@ -90,6 +90,7 @@ if __name__ == "__main__":
 
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     if args.rw == 'write':
         is_write = True

--- a/rowhammer_tester/scripts/bios_console.py
+++ b/rowhammer_tester/scripts/bios_console.py
@@ -9,7 +9,7 @@ import shutil
 
 from litex.tools.litex_term import LiteXTerm
 
-from rowhammer_tester.scripts.utils import RemoteClient, litex_server
+from rowhammer_tester.scripts.utils import RemoteClient, litex_server, read_ident
 
 
 def pty2crossover(m, stop):
@@ -43,6 +43,7 @@ if __name__ == "__main__":
 
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     m, s = pty.openpty()
     tty = os.ttyname(s)

--- a/rowhammer_tester/scripts/dump_regs.py
+++ b/rowhammer_tester/scripts/dump_regs.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-from rowhammer_tester.scripts.utils import RemoteClient
+from rowhammer_tester.scripts.utils import RemoteClient, read_ident
 
 if __name__ == "__main__":
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     # Dump all CSR registers of the SoC
     for name, reg in wb.regs.__dict__.items():

--- a/rowhammer_tester/scripts/execute_payload.py
+++ b/rowhammer_tester/scripts/execute_payload.py
@@ -6,7 +6,7 @@ import time
 import itertools
 
 from rowhammer_tester.gateware.payload_executor import Encoder, OpCode, Decoder
-from rowhammer_tester.scripts.utils import memdump, memread, memwrite, DRAMAddressConverter, RemoteClient
+from rowhammer_tester.scripts.utils import memdump, memread, memwrite, DRAMAddressConverter, RemoteClient, read_ident
 
 # Sample program
 encoder = Encoder(bankbits=3)
@@ -91,6 +91,7 @@ def execute(wb):
 if __name__ == "__main__":
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     execute(wb)
 

--- a/rowhammer_tester/scripts/leds.py
+++ b/rowhammer_tester/scripts/leds.py
@@ -3,7 +3,7 @@
 import time
 import argparse
 
-from rowhammer_tester.scripts.utils import RemoteClient, litex_server
+from rowhammer_tester.scripts.utils import RemoteClient, litex_server, read_ident
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -16,6 +16,7 @@ if __name__ == "__main__":
 
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     i = 1
     left = True

--- a/rowhammer_tester/scripts/mem.py
+++ b/rowhammer_tester/scripts/mem.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
 
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     print(' === Waiting for CPU to initialize DRAM ===')
     if hasattr(wb.regs, "uart_xover_rxempty"):

--- a/rowhammer_tester/scripts/mem_bist.py
+++ b/rowhammer_tester/scripts/mem_bist.py
@@ -6,7 +6,7 @@ import argparse
 
 from datetime import datetime
 
-from rowhammer_tester.scripts.utils import RemoteClient, litex_server, hw_memset, hw_memtest, get_litedram_settings
+from rowhammer_tester.scripts.utils import RemoteClient, litex_server, hw_memset, hw_memtest, get_litedram_settings, read_ident
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -21,6 +21,7 @@ if __name__ == "__main__":
 
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     mem_base = wb.mems.main_ram.base
     mem_range = wb.mems.main_ram.size  # bytes

--- a/rowhammer_tester/scripts/read_level.py
+++ b/rowhammer_tester/scripts/read_level.py
@@ -344,6 +344,7 @@ def write_level_hardcoded(wb, cdly, delays):
 if __name__ == "__main__":
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     read_level(wb, Settings.load())
 

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 from rowhammer_tester.scripts.utils import (
     memfill, memcheck, memwrite, DRAMAddressConverter, litex_server, RemoteClient,
-    get_litedram_settings, get_generated_defs, execute_payload)
+    get_litedram_settings, get_generated_defs, execute_payload, read_ident)
 from rowhammer_tester.scripts.playbook.lib import (generate_payload_from_row_list)
 
 ################################################################################
@@ -444,6 +444,7 @@ def main(row_hammer_cls):
 
     wb = RemoteClient()
     wb.open()
+    print("Board info:", read_ident(wb))
 
     if wb.regs.ddrctrl_init_done.read() != 1:
         scripts_dir = os.path.dirname(os.path.realpath(__file__))

--- a/rowhammer_tester/scripts/spd_eeprom.py
+++ b/rowhammer_tester/scripts/spd_eeprom.py
@@ -11,7 +11,7 @@ from pexpect import replwrap
 
 from litedram.modules import parse_spd_hexdump, SDRAMModule
 
-from rowhammer_tester.scripts.utils import get_generated_defs, RemoteClient, litex_server
+from rowhammer_tester.scripts.utils import get_generated_defs, RemoteClient, litex_server, read_ident
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
 
@@ -106,6 +106,7 @@ if __name__ == "__main__":
         console = pexpect.spawn('python bios_console.py -t litex_term', cwd=SCRIPT_DIR, timeout=6)
         wb = RemoteClient()
         wb.open()
+        print("Board info:", read_ident(wb))
         if not wb.regs.ddrctrl_init_done.read():
             print('Waiting for CPU to finish memory training ...')
             for i in range(args.mem_timeout):

--- a/rowhammer_tester/scripts/utils.py
+++ b/rowhammer_tester/scripts/utils.py
@@ -225,6 +225,19 @@ def memdump(data, base=0x40000000, chunk_len=16):
         print("0x{addr:08x}:  {bytes}  {chars}".format(addr=base + chunk_len * i, bytes=b, chars=c))
 
 
+def read_ident(wb) -> str:
+    # Maximal identification info size is 256
+    buildinfo = memread(wb, 256, wb.bases.identifier_mem)
+
+    # Info is stored as a \0 terminated string
+    # truncate it
+    string_term_idx = buildinfo.index(0)
+    buildinfo = buildinfo[:string_term_idx]
+
+    # Decode ASCII characters
+    return bytes(buildinfo).decode("ascii")
+
+
 ################################################################################
 
 
@@ -566,3 +579,4 @@ if __name__ == "__main__":
     if bool(getattr(sys, 'ps1', sys.flags.interactive)):
         wb = RemoteClient()
         wb.open()
+        print("Board info:", read_ident(wb))

--- a/rowhammer_tester/scripts/version.py
+++ b/rowhammer_tester/scripts/version.py
@@ -1,20 +1,11 @@
 #!/usr/bin/env python3
 
-from rowhammer_tester.scripts.utils import RemoteClient, memread
+from rowhammer_tester.scripts.utils import RemoteClient, read_ident
 
 if __name__ == "__main__":
     wb = RemoteClient()
     wb.open()
 
-    # Maximal identification info size is 256
-    buildinfo = memread(wb, 256, wb.bases.identifier_mem)
-
-    # Info is stored as a \0 terminated string
-    # truncate it
-    string_term_idx = buildinfo.index(0)
-    buildinfo = buildinfo[:string_term_idx]
-
-    # Map int values to ASCII characters
-    print(''.join(map(chr, buildinfo)))
+    print(read_ident(wb))
 
     wb.close()


### PR DESCRIPTION
This PR moves part of `version.py` body to separate function `read_ident` in `utils.py` so it can be used in other places as well.

In particular, I added `read_ident` call after each `wb.open()` in current scripts, so it is easier to share used configuration when copying console log.

<details>
<summary>
Example log. Notice board info in the second line of the output
</summary>
<p>

```
$ TARGET=ddr4_datacenter_test_board python rowhammer_tester/scripts/bios_console.py
Using generated target files in: build/ddr4_datacenter_test_board
Board info: Row Hammer Tester SoC on xc7k160tffg676-1, git: ae0efa3e328830c277e2f712c700bfbb48b0812f 2022-11-23 14:28:01
LiteX Crossover UART created: /dev/pts/6
Using serial backend: auto
picocom v3.1

port is        : /dev/pts/6
flowcontrol    : none
baudrate is    : 1000000
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
hangup is      : no
nolock is      : no
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        :
omap is        :
emap is        : crcrlf,delbs,
logfile is     : none
initstring     : none
exit_after is  : not set
exit is        : no

Type [C-a] [C-h] to see available commands
Terminal ready

        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2022 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Nov 23 2022 14:28:04
 BIOS CRC passed (c5d12b2a)

 LiteX git sha1: a63ec872b

--=============== SoC ==================--
CPU:            VexRiscv_Min @ 100MHz
BUS:            WISHBONE 32-bit @ 4GiB
CSR:            32-bit data
ROM:            64KiB
SRAM:           8KiB
L2:             0KiB
SDRAM:          1048576KiB 64-bit @ 800MT/s (CL-9 CWL-9)

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Write latency calibration:
m0:6 m1:6 m2:6 m3:6 m4:6 m5:6 m6:6 m7:6 m8:6 m9:6 m10:6 m11:6 m12:6 m13:6 m14:6 m15:6
Read leveling:
  m0, b00: |00000000000000000000000000000000| delays: -
  m0, b01: |00000000000000000000000000000000| delays: -
  m0, b02: |00000000000000000000000000000000| delays: -
  m0, b03: |11111111000000000000000000000000| delays: 03+-03
  m0, b04: |00000000001111111111111100000000| delays: 17+-07
  m0, b05: |00000000000000000000000000011111| delays: 29+-02
  m0, b06: |00000000000000000000000000000000| delays: -
  m0, b07: |00000000000000000000000000000000| delays: -
  best: m0, b04 delays: 17+-07
  m1, b00: |00000000000000000000000000000000| delays: -
  m1, b01: |00000000000000000000000000000000| delays: -
  m1, b02: |00000000000000000000000000000000| delays: -
  m1, b03: |11111111000000000000000000000000| delays: 04+-04
  m1, b04: |00000000001111111111111110000000| delays: 17+-07
  m1, b05: |00000000000000000000000000001111| delays: 30+-02
  m1, b06: |00000000000000000000000000000000| delays: -
  m1, b07: |00000000000000000000000000000000| delays: -
  best: m1, b04 delays: 17+-07

...
```
</p>
</details>