### PR TITLE
Add `make pack` target and some small fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install git build-essential autoconf cmake ninja-build flex libfl-dev bison libftdi-dev
           sudo apt-get install libjson-c-dev libevent-dev libtinfo-dev uml-utilities python3 python3-venv python3-wheel
           sudo apt-get install libftdi1-2 libftdi1-dev libhidapi-hidraw0 libhidapi-dev libudev-dev pkg-config tree zlib1g-dev
-          sudo make deps
+          make deps
 
       - name: Check targets
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install git build-essential autoconf cmake ninja-build flex libfl-dev bison libftdi-dev
           sudo apt-get install libjson-c-dev libevent-dev libtinfo-dev uml-utilities python3 python3-venv python3-wheel
-          sudo apt-get install libftdi1-2 libftdi1-dev libhidapi-hidraw0 libhidapi-dev libudev-dev pkg-config tree zlib1g-dev
+          sudo apt-get install libftdi1-2 libftdi1-dev libhidapi-hidraw0 libhidapi-dev libudev-dev pkg-config tree zlib1g-dev zip unzip
           make deps
 
       - name: Check targets

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ venv/bin/verilator: third_party/verilator/configure.ac
 
 venv/bin/openFPGALoader: third_party/openFPGALoader/CMakeLists.txt
 	cd third_party/openFPGALoader && cmake . -DCMAKE_INSTALL_PREFIX=$(PWD)/venv
-	cd third_party/openFPGALoader && cmake --build . -j`nproc`
+	cd third_party/openFPGALoader && cmake --build . -j `nproc`
 	cd third_party/openFPGALoader && cmake --install .
 
 # required for flashing LPDDR4 board

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,14 @@ format: FORCE
 		--exclude "rowhammer_tester/targets/*" \
 		$(PYTHON_FILES)
 
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD | tr '/' '_')
+COMMIT := $(shell git rev-parse HEAD | head -c8)
+ZIP_CONTENTS := $(addprefix build/$(TARGET)/,csr.csv defs.csv sdram_init.py litedram_settings.json gateware/$(TOP).bit)
+
+.PHONY: pack
+pack: $(ZIP_CONTENTS)
+	zip -r "$(TARGET)-$(BRANCH)-$(COMMIT).zip" $^
+
 ### Dependencies ###
 
 deps:: # Intentionally skipping --recursive as not needed (but doesn't break anything either)

--- a/Makefile
+++ b/Makefile
@@ -133,12 +133,10 @@ python-deps: venv/bin/activate  # installs python dependencies inside virtual en
 venv/bin/activate:  # creates virtual environment if it does not exist
 	python3 -m venv venv
 
-# `litex_setup.py` will avoid downloading to directories with .gitignore, so we install in third_party/
 third_party/riscv64-unknown-elf-gcc:
-	cd third_party/ && python litex/litex_setup.py gcc dev
-	find third_party/ -name 'riscv64-unknown-elf-gcc*' -type d \
-		-exec mv {} third_party/riscv64-unknown-elf-gcc \; \
-		-quit
+	@echo Downloading RISC-V toolchain
+	curl -L https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.08/riscv64-unknown-elf-gcc-10.1.0-2020.08.2-x86_64-linux-ubuntu14.tar.gz | tar -xzf -
+	mv riscv64-unknown-elf-gcc-10.1.0-2020.08.2-x86_64-linux-ubuntu14 third_party/riscv64-unknown-elf-gcc
 
 venv/bin/verilator: third_party/verilator/configure.ac
 	cd third_party/verilator && autoconf

--- a/Makefile
+++ b/Makefile
@@ -116,12 +116,16 @@ pack: $(ZIP_CONTENTS)
 
 ### Dependencies ###
 
-deps:: # Intentionally skipping --recursive as not needed (but doesn't break anything either)
+minimal-deps:: # Intentionally skipping --recursive as not needed (but doesn't break anything either)
 	git submodule update --init
 	(make --no-print-directory -C . \
 		venv/bin/openFPGALoader \
-		venv/bin/openocd \
 		python-deps \
+	)
+
+deps: minimal-deps
+	(make --no-print-directory -C . \
+		venv/bin/openocd \
 		third_party/riscv64-unknown-elf-gcc \
 	)
 

--- a/doc/general.md
+++ b/doc/general.md
@@ -32,7 +32,7 @@ and [OpenOCD](https://github.com/openocd-org/openocd).
 To install the dependencies on Ubuntu 18.04 LTS, run:
 
 ```sh
-apt install git build-essential autoconf cmake flex bison libftdi-dev libjson-c-dev libevent-dev libtinfo-dev uml-utilities python3 python3-venv python3-wheel protobuf-compiler libcairo2 libftdi1-2 libftdi1-dev libhidapi-hidraw0 libhidapi-dev libudev-dev pkg-config tree zlib1g-dev
+apt install git build-essential autoconf cmake flex bison libftdi-dev libjson-c-dev libevent-dev libtinfo-dev uml-utilities python3 python3-venv python3-wheel protobuf-compiler libcairo2 libftdi1-2 libftdi1-dev libhidapi-hidraw0 libhidapi-dev libudev-dev pkg-config tree zlib1g-dev zip unzip
 ```
 
 ````{note}

--- a/doc/general.md
+++ b/doc/general.md
@@ -84,6 +84,22 @@ source /PATH/TO/Vivado/VERSION/settings64.sh
 
 All other commands assume that you run Python from the virtual environment with `vivado` in your `PATH`.
 
+## Packaging the bitstream
+
+If you want to save the bitstream and use it later or share it with someone, there is an utility target `make pack`.
+It packs files necessary to load the bitstream and run rowhammer scripts on it.
+Those files are:
+ - `build/$TARGET/gateware/$TOP.bit`
+ - `build/$TARGET/csr.csv`
+ - `build/$TARGET/defs.csv`
+ - `build/$TARGET/sdram_init.py`
+ - `build/$TARGET/litedram_settings.json`
+
+After running `make pack`, you should have a zip file named like `$TARGET-$BRANCH-$COMMIT.zip`.
+
+Next time you want to use a bitstream packaged in such way, all you need to do is to run
+`unzip your-bitstream-file.zip` and you are all set.
+
 ## Local documentation build
 
 The gateware part of the documentation is auto-generated from source files.

--- a/rowhammer_tester/scripts/benchmark.py
+++ b/rowhammer_tester/scripts/benchmark.py
@@ -92,15 +92,15 @@ if __name__ == "__main__":
     wb.open()
     print("Board info:", read_ident(wb))
 
+    if args.subcommand is None:
+        parser.error('Select subcommand')
+
     if args.rw == 'write':
         is_write = True
     elif args.rw == 'read':
         is_write = False
     else:
         raise ValueError(args.rw)
-
-    if args.subcommand is None:
-        parser.error('Select subcommand')
 
     if args.subcommand == 'etherbone':
         run_etherbone(wb, is_write, int(args.n, 0), burst=int(args.burst, 0), profile=args.profile)


### PR DESCRIPTION
This PR adds `make pack` target, which allows to conveniently pack the bitstream with all required files for future use.

With such packed bitstream you don't need to have a RISC-V toolchain (and openocd is required only for flashing), so I created `minimal-deps` for such situations.

Regarding RISC-V toolchain, I modified `riscv64-unknown-elf-gcc` target, so it works like old `litex_setup.py gcc`, that is downloading a specific archive with the toolchain and using it.
The current method of using distro installed toolchain requires `sudo` privileges and means that different users will have different compiler versions depending on their distro, which may prove difficult when resolving issues.

Additionally, I added two small fixes:
 - one in benchmark.py script which fixes an exception
 - and one in `Makefile`, which allows usage of older CMake versions