### PR TITLE
Build with litex bist by default

### DIFF
--- a/rowhammer_tester/targets/common.py
+++ b/rowhammer_tester/targets/common.py
@@ -198,7 +198,7 @@ class RowHammerSoC(SoCCore):
             size                    = kwargs.get("max_sdram_size", 0x40000000),
             l2_cache_size           = 256,
             controller_settings     = controller_settings,
-            with_bist               = args.with_litex_bist
+            with_bist               = not args.no_litex_bist
         )
 
         # CPU will report that leveling finished by writing to ddrctrl CSRs
@@ -395,7 +395,7 @@ class ArgumentParser(argparse.ArgumentParser):
         self.add(g, "--from-spd", required=False, help="Use DRAM module data from given file. Overwrites --module")
         self.add(g, "--speedgrade", default=None, help="DRAM module speedgrade, default value depends on module")
         self.add(g, "--no-memory-bist", action="store_true", help="Disable memory BIST module")
-        self.add(g, "--with-litex-bist", action="store_true", help="Enable BIST modules functionality from LiteX")
+        self.add(g, "--no-litex-bist", action="store_true", help="Disable BIST modules functionality from LiteX")
         self.add(g, "--pattern-data-size", default="1024", help="BIST pattern data memory size in bytes")
         self.add(g, "--no-payload-executor", action="store_true", help="Disable Payload Executor module")
         self.add(g, "--payload-size", default="32768", help="Payload memory size in bytes")


### PR DESCRIPTION
This is necessary to use the `sdram_hw_test` command.